### PR TITLE
test: created a container inside the 'log in' view

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,5 @@
+<div class='container'>
+
 <h2>Log in</h2>
 
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name),
@@ -19,3 +21,5 @@
 <% end %>
 
 <%= render "devise/shared/links" %>
+
+</div>


### PR DESCRIPTION
For this test, I put the Log In view inside a container

<img width="1194" alt="Capture d’écran 2022-11-21 à 15 38 29" src="https://user-images.githubusercontent.com/26471726/203082358-ea3e0ec4-aefb-4089-bc05-58c7f174ddc4.png">
