### PR TITLE
calul du nombre de jours dans le calendrier _ stimulus

### DIFF
--- a/app/javascript/controllers/date_picker_controller.js
+++ b/app/javascript/controllers/date_picker_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+// data value
+export default class extends Controller {
+  static values = {
+    price: Number
+  }
+  static targets = [ "startDate", "endDate", "totalPrice" ]
+
+  connect() {
+    console.log(this.priceValue);
+    console.log(this.startDateTarget.value);
+    console.log(this.endDateTarget.value);
+  }
+
+  computePrice() {
+    console.log(this.priceValue);
+    console.log(this.startDateTarget.value);
+    console.log(this.endDateTarget.value);
+
+    const start = new Date(this.startDateTarget.value);
+    const end = new Date(this.endDateTarget.value);
+    const sub = end.getTime()-start.getTime();
+    console.log(sub /(1000 * 3600 * 24) * this.priceValue);
+    this.totalPriceTarget.innerText = sub /(1000 * 3600 * 24) * this.priceValue
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import DatePickerController from "./date_picker_controller"
+application.register("date-picker", DatePickerController)
+
 import FlatpickrController from "./flatpickr_controller"
 application.register("flatpickr", FlatpickrController)
 

--- a/app/views/offers/_form_booking.html.erb
+++ b/app/views/offers/_form_booking.html.erb
@@ -1,18 +1,19 @@
 
 <div class="container">
   <div class="row justify-content-center">
-    <div class="col-12 col-lg-6">
+    <div class="col-12 col-lg-6" data-controller="date-picker" data-date-picker-price-value="<%= @offer.price %>">
       <%= simple_form_for [@offer, @booking] do |f| %>
         <%= f.input :start_date, as: :string,
                 wrapper_html: { class: "mb-4" },
                 label_html: { class: "form-label text-secondary fw-bold" },
-                input_html: { data: { controller: "flatpickr" } } %>
+                input_html: { data: { controller: "flatpickr", date_picker_target: 'startDate', action: 'input->date-picker#computePrice' } } %>
         <%= f.input :end_date, as: :string,
                 wrapper_html: { class: "mb-4" },
                 label_html: { class: "form-label text-secondary fw-bold" },
-                input_html: { data: { controller: "flatpickr" } } %>
+                input_html: { data: { controller: "flatpickr" , date_picker_target: 'endDate', action: 'input->date-picker#computePrice' }  } %>
         <%= f.submit %>
       <% end %>
+      <div data-date-picker-target="totalPrice"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
flatpickr permet de calculer le nombre total de jours et le prix total de la réservation.
stimulus et JS